### PR TITLE
Return the identifier provided in the Location header when creating a contact

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -3,6 +3,7 @@ package starling
 import (
 	"context"
 	"net/http"
+	"path"
 )
 
 // Contact represents the details of a payee
@@ -106,12 +107,15 @@ func (c *Client) ContactAccount(ctx context.Context, cUID, aUID string) (*Contac
 }
 
 // CreateContactAccount creates the specified account for a given contact.
-func (c *Client) CreateContactAccount(ctx context.Context, ca ContactAccount) (*http.Response, error) {
+func (c *Client) CreateContactAccount(ctx context.Context, ca ContactAccount) (string, *http.Response, error) {
 	req, err := c.NewRequest("POST", "/api/v1/contacts", ca)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	resp, err := c.Do(ctx, req, nil)
-	return resp, err
+	loc := resp.Header.Get("Location")
+	uid := path.Base(loc)
+
+	return uid, resp, err
 }

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -484,16 +484,20 @@ func testPostContactAccount(t *testing.T, name string, ca ContactAccount, respBo
 		if !reflect.DeepEqual(ca, reqCA) {
 			t.Error("should send a contact account that matches the mock", cross)
 		}
-
+		w.Header().Set("Location", reqCA.UID)
 		w.WriteHeader(respStatus)
 		fmt.Fprintln(w, respBody)
 	})
 
-	resp, err := client.CreateContactAccount(context.Background(), ca)
+	uid, resp, err := client.CreateContactAccount(context.Background(), ca)
 	if respStatus <= 299 {
 		checkNoError(t, err)
 	} else {
 		checkHasError(t, err)
+	}
+
+	if uid != ca.UID {
+		t.Error("should return the UID in the Location header")
 	}
 
 	checkStatus(t, resp, respStatus)


### PR DESCRIPTION
Fixes #16 by returning the identifier provided in the Location header when creating a contact.