### PR TITLE
Account balance: add support for v2 endpoint, adjust JSON response

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -80,20 +80,40 @@ func (c *Client) AccountID(ctx context.Context, uid string) (*AccountID, *http.R
 	return actID, resp, err
 }
 
-// Balance represents the balance on an account
 type Balance struct {
-	Cleared     float64 `json:"clearedBalance"`
-	Effective   float64 `json:"effectiveBalance"`
-	PendingTxns float64 `json:"pendingTransactions"`
-	Available   float64 `json:"availableToSpend"`
-	Overdraft   float64 `json:"acceptedOverdraft"`
-	Currency    string  `json:"currency"`
-	Amount      float64 `json:"amount"`
+	ClearedBalance struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"clearedBalance"`
+	EffectiveBalance struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"effectiveBalance"`
+	PendingTransactions struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"pendingTransactions"`
+	AcceptedOverdraft struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"acceptedOverdraft"`
+	Amount struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"amount"`
+	TotalClearedBalance struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"totalClearedBalance"`
+	TotalEffectiveBalance struct {
+		Currency   string `json:"currency"`
+		MinorUnits int    `json:"minorUnits"`
+	} `json:"totalEffectiveBalance"`
 }
 
 // AccountBalance returns the the account balance for the current customer.
-func (c *Client) AccountBalance(ctx context.Context) (*Balance, *http.Response, error) {
-	req, err := c.NewRequest("GET", "/api/v1/accounts/balance", nil)
+func (c *Client) AccountBalance(ctx context.Context, uid string) (*Balance, *http.Response, error) {
+    req, err := c.NewRequest("GET", "/api/v2/accounts/"+uid+"/balance", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/accounts.go
+++ b/accounts.go
@@ -81,36 +81,14 @@ func (c *Client) AccountID(ctx context.Context, uid string) (*AccountID, *http.R
 }
 
 type Balance struct {
-	ClearedBalance struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"clearedBalance"`
-	EffectiveBalance struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"effectiveBalance"`
-	PendingTransactions struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"pendingTransactions"`
-	AcceptedOverdraft struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"acceptedOverdraft"`
-	Amount struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"amount"`
-	TotalClearedBalance struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"totalClearedBalance"`
-	TotalEffectiveBalance struct {
-		Currency   string `json:"currency"`
-		MinorUnits int    `json:"minorUnits"`
-	} `json:"totalEffectiveBalance"`
+	Cleared CurrencyAndAmount `json:"clearedBalance"`
+	Effective CurrencyAndAmount `json:"effectiveBalance"`
+	PendingTxns CurrencyAndAmount `json:"pendingTransactions"`
+	OverDraft CurrencyAndAmount `json:"acceptedOverdraft"`
+	Amount CurrencyAndAmount `json:"amount"`
+	TotalCleared CurrencyAndAmount `json:"totalClearedBalance"`
+	TotalEffective CurrencyAndAmount `json:"totalEffectiveBalance"`
 }
-
 // AccountBalance returns the the account balance for the current customer.
 func (c *Client) AccountBalance(ctx context.Context, uid string) (*Balance, *http.Response, error) {
     req, err := c.NewRequest("GET", "/api/v2/accounts/"+uid+"/balance", nil)

--- a/common.go
+++ b/common.go
@@ -1,0 +1,6 @@
+package starling
+
+type CurrencyAndAmount struct {
+	Currency string `json:"currency"`
+	MinorUnits int `json:"minorUnits"`
+}


### PR DESCRIPTION
I have changed the `AccountBalance` function to accept `context`, and a
string parameter of the accountUid. This will be a breaking change to
the library.

The `Balance` struct now contains new fields, including a nested struct
for each field as per the JSON representation from the Starling Bank
`/balance` v2 API endpoint.

Additionally, instead of using `float64`, we now use `int`, as Starling
return the monetary amounts as an integer, and do *not* use
floating-point numbers. I'm working to add further v2 API support to
this library and the Savings Goals need updating as well to use `int`
and the `CurrencyAndAmount` JSON object (this object may be represented
into a common struct in the future for reusability!).

A future commit should be made to adjust the AccountBalance test and
mock JSON response.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>